### PR TITLE
Add Strings::stripTags

### DIFF
--- a/src/Filter/Strings.php
+++ b/src/Filter/Strings.php
@@ -71,6 +71,23 @@ final class Strings
         return explode($delimiter, $value);
     }
 
+    /**
+     * Strip HTML and PHP tags from a string. Unlike the strip_tags function this method will return null if a null
+     * value is given. The native php function will return an empty string.
+     *
+     * @param string|null $value The input string
+     *
+     * @return string|null
+     */
+    public static function stripTags(string $value = null)
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return strip_tags($value);
+    }
+
     private static function validateMinimumLength(int $minLength)
     {
         if ($minLength < 0) {

--- a/tests/Filter/StringsTest.php
+++ b/tests/Filter/StringsTest.php
@@ -246,4 +246,24 @@ final class StringsTest extends TestCase
     {
         Strings::explode('test', '');
     }
+
+    /**
+     * @test
+     * @covers ::stripTags
+     */
+    public function stripTagsFromNullReturnsNull()
+    {
+        $this->assertNull(Strings::stripTags(null));
+    }
+
+    /**
+     * @test
+     * @covers ::stripTags
+     */
+    public function stripTagsRemoveHtmlFromString()
+    {
+        $actual = Strings::stripTags('A string with <p>paragraph</p> tags');
+        $expected = 'A string with paragraph tags';
+        $this->assertSame($expected, $actual);
+    }
 }


### PR DESCRIPTION
#### What does this PR do?
This pull request adds `Strings::stripTags` which uses the native function `strip_tags`, but unlike the native function, `Strings::stripTags` will return null if a null value is given. The native function returns an empty string when given a null value.
#### Checklist
- [  ] Pull request contains a clear definition of changes
- [  ] Tests (either unit, integration, or acceptance) written and passing
- [  ] Relevant documentation produced and/or updated

