### PR TITLE
Enhance strip-tags filter to allow a replacement value

### DIFF
--- a/src/Filter/Strings.php
+++ b/src/Filter/Strings.php
@@ -106,20 +106,28 @@ final class Strings
     }
 
     /**
-     * Strip HTML and PHP tags from a string. Unlike the strip_tags function this method will return null if a null
-     * value is given. The native php function will return an empty string.
+     * Strip HTML and PHP tags from a string and, optionally, replace the tags with a string.
+     * Unlike the strip_tags function, this method will return null if a null value is given.
+     * The native php function will return an empty string.
      *
-     * @param string|null $value The input string
+     * @param string|null $value       The input string.
+     * @param string      $replacement The string to replace the tags with. Defaults to an empty string.
      *
      * @return string|null
      */
-    public static function stripTags(string $value = null)
+    public static function stripTags(string $value = null, string $replacement = '')
     {
         if ($value === null) {
             return null;
         }
 
-        return strip_tags($value);
+        if ($replacement === '') {
+            return strip_tags($value);
+        }
+
+        $findTagEntities = '/<[^>]+?>/';
+        $valueWithReplacements = preg_replace($findTagEntities, $replacement, $value);
+        return strip_tags($valueWithReplacements); // use built-in as a safeguard to ensure tags are stripped
     }
 
     private static function validateMinimumLength(int $minLength)

--- a/tests/Filter/StringsTest.php
+++ b/tests/Filter/StringsTest.php
@@ -273,21 +273,65 @@ final class StringsTest extends TestCase
     /**
      * @test
      * @covers ::stripTags
+     * @dataProvider provideStripTags
+     *
+     * @param string|null $value
+     * @param string      $replacement
+     * @param string|null $expected
      */
-    public function stripTagsFromNullReturnsNull()
+    public function stripTags($value, string $replacement, $expected)
     {
-        $this->assertNull(Strings::stripTags(null));
+        $actual = Strings::stripTags($value, $replacement);
+        $this->assertSame($expected, $actual);
     }
 
     /**
-     * @test
-     * @covers ::stripTags
+     * @return array
      */
-    public function stripTagsRemoveHtmlFromString()
+    public function provideStripTags()
     {
-        $actual = Strings::stripTags('A string with <p>paragraph</p> tags');
-        $expected = 'A string with paragraph tags';
-        $this->assertSame($expected, $actual);
+        return [
+            'null returns null' => [
+                'value' => null,
+                'replacement' => '',
+                'expected' => null,
+            ],
+            'remove html from string' => [
+                'value' => 'A string with <p>paragraph</p> tags',
+                'replacement' => '',
+                'expected' => 'A string with paragraph tags',
+            ],
+            'remove xml and replace with space' => [
+                'value' => '<something>inner value</something>',
+                'replacement' => ' ',
+                'expected' => ' inner value ',
+            ],
+            'remove multiline html from string' => [
+                'value' => "<p\nclass='something'\nstyle='display:none'></p>",
+                'replacement' => ' ',
+                'expected' => '  ',
+            ],
+            'remove php tags' => [
+                'value' => '<?php some php code',
+                'replacement' => ' ',
+                'expected' => '',
+            ],
+            'remove shorthand php tags' => [
+                'value' => '<?= some php code ?> something else',
+                'replacement' => ' ',
+                'expected' => '  something else',
+            ],
+            'do not remove unmatched <' => [
+                'value' => '1 < 3',
+                'replacement' => ' ',
+                'expected' => '1 < 3',
+            ],
+            'do not remove unmatched >' => [
+                'value' => '3 > 1',
+                'replacement' => ' ',
+                'expected' => '3 > 1',
+            ],
+        ];
     }
 
     /**


### PR DESCRIPTION
#### What does this PR do?
This pull request enhances the strip-tags filter to allow the tags to be replaced with a provided string. For instance, you might want to replace the stripped tags with a space so that words don't collide after removing the tags.

#### Checklist
- [X] Pull request contains a clear definition of changes
- [X] Tests (either unit, integration, or acceptance) written and passing
- [X] Relevant documentation produced and/or updated

