### PR TITLE
Add optional result keys to the Strings::explode

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ with the value first in order to work with the `Filterer`.  It also defaults to 
 $value = \TraderInteractive\Filter\Strings::explode('abc,def,ghi');
 assert($value === ['abc', 'def', 'ghi']);
 ```
+The filter can optionally be given keys to be used in the result. For example:
+```php
+$value = \TraderInteractive\Filter\Strings::explode('def,ghi', ',', ['foo', 'bar', 'baz']);
+assert($value === ['baz'=> 'ghi', 'bar' => 'def', 'foo' => null]);
+```
 
 #### Strings::compress
 This filter trims and remove superfluous whitespace from a given string.

--- a/src/Filter/Strings.php
+++ b/src/Filter/Strings.php
@@ -52,13 +52,15 @@ final class Strings
      *
      * For example, given the string 'foo,bar,baz', this would return the array ['foo', 'bar', 'baz'].
      *
-     * @param string $value The string to explode.
-     * @param string $delimiter The non-empty delimiter to explode on.
+     * @param string     $value     The string to explode.
+     * @param string     $delimiter The non-empty delimiter to explode on.
+     * @param array|null $keys      If provided the values from the exploded string will be assigned the given keys.
+     *
      * @return array The exploded values.
      *
      * @throws \InvalidArgumentException if the delimiter does not pass validation.
      */
-    public static function explode($value, string $delimiter = ',')
+    public static function explode($value, string $delimiter = ',', array $keys = null)
     {
         self::validateIfObjectIsAString($value);
 
@@ -68,7 +70,18 @@ final class Strings
             );
         }
 
-        return explode($delimiter, $value);
+        $values = explode($delimiter, $value);
+        if ($keys === null) {
+            return $values;
+        }
+
+        $result = [];
+        foreach (array_reverse($keys) as $key) {
+            $value = array_pop($values);
+            $result[$key] = $value;
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/Filter/StringsTest.php
+++ b/tests/Filter/StringsTest.php
@@ -548,4 +548,28 @@ final class StringsTest extends TestCase
             ],
         ];
     }
+
+    /**
+     * @test
+     * @covers ::explode
+     */
+    public function explodeWithResultKeys()
+    {
+        $keys = ['optional', 'required'];
+        $input = 'abc-1';
+        $result = Strings::explode($input, '-', $keys);
+        $this->assertSame(['required' => '1', 'optional' => 'abc'], $result);
+    }
+
+    /**
+     * @test
+     * @covers ::explode
+     */
+    public function explodeWithResultKeysAndNullResult()
+    {
+        $keys = ['optional', 'required'];
+        $input = 'abc';
+        $result = Strings::explode($input, '-', $keys);
+        $this->assertSame(['required' => 'abc', 'optional' => null], $result);
+    }
 }


### PR DESCRIPTION
#### What does this PR do?
This pull request adds optional keys parameter to Strings::explode to be used in the resulting array.
#### Checklist
- [  ] Pull request contains a clear definition of changes
- [  ] Tests (either unit, integration, or acceptance) written and passing
- [  ] Relevant documentation produced and/or updated

