### PR TITLE
Allow padding of result in Strings::explode

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,11 @@ with the value first in order to work with the `Filterer`.  It also defaults to 
 $value = \TraderInteractive\Filter\Strings::explode('abc,def,ghi');
 assert($value === ['abc', 'def', 'ghi']);
 ```
-
+This filter can also be given padding settings to ensure the result has a specific number of elements. For example:
+```php
+$value = Strings::explode('a-b-c', '-', 5, '', Strings::EXPLODE_PAD_LEFT);
+assert($value === [null, null, 'a', 'b', 'c']);
+```
 #### Strings::compress
 This filter trims and remove superfluous whitespace from a given string.
 ```php

--- a/src/Filter/Strings.php
+++ b/src/Filter/Strings.php
@@ -2,6 +2,7 @@
 
 namespace TraderInteractive\Filter;
 
+use InvalidArgumentException;
 use TraderInteractive\Exceptions\FilterException;
 use TypeError;
 
@@ -10,6 +11,16 @@ use TypeError;
  */
 final class Strings
 {
+    /**
+     * @var string
+     */
+    const EXPLODE_PAD_LEFT = 'left';
+
+    /**
+     * @var string
+     */
+    const EXPLODE_PAD_RIGHT = 'right';
+
     /**
      * Filter a string.
      *
@@ -52,14 +63,23 @@ final class Strings
      *
      * For example, given the string 'foo,bar,baz', this would return the array ['foo', 'bar', 'baz'].
      *
-     * @param string $value The string to explode.
-     * @param string $delimiter The non-empty delimiter to explode on.
+     * @param string     $value     The string to explode.
+     * @param string     $delimiter The non-empty delimiter to explode on.
+     * @param int|null   $padLength The number of elements to be returned in the result.
+     * @param mixed      $padValue  The value to use when padding the resulting array.
+     * @param string     $padType   Argument to specify if the resulting array should be padded on the left or right.
+     *
      * @return array The exploded values.
      *
      * @throws \InvalidArgumentException if the delimiter does not pass validation.
      */
-    public static function explode($value, string $delimiter = ',')
-    {
+    public static function explode(
+        $value,
+        string $delimiter = ',',
+        int $padLength = null,
+        $padValue = null,
+        string $padType = self::EXPLODE_PAD_RIGHT
+    ) : array {
         self::validateIfObjectIsAString($value);
 
         if (empty($delimiter)) {
@@ -68,7 +88,23 @@ final class Strings
             );
         }
 
-        return explode($delimiter, $value);
+        $values = explode($delimiter, $value);
+        $padLength = $padLength ?? count($values);
+        while (count($values) < $padLength) {
+            if ($padType === self::EXPLODE_PAD_RIGHT) {
+                array_push($values, $padValue);
+                continue;
+            }
+
+            if ($padType === self::EXPLODE_PAD_LEFT) {
+                array_unshift($values, $padValue);
+                continue;
+            }
+
+            throw new InvalidArgumentException('Invalid $padType value provided');
+        }
+
+        return $values;
     }
 
     /**

--- a/tests/Filter/PhoneFilterTest.php
+++ b/tests/Filter/PhoneFilterTest.php
@@ -92,7 +92,7 @@ final class PhoneFilterTest extends TestCase
      * @param mixed $value The value to filter.
      *
      * @test
-     * @covers ::__invoke
+     * @covers ::filter
      * @dataProvider provideFilterThrowsException
      */
     public function filterThrowsException($value)

--- a/tests/Filter/StringsTest.php
+++ b/tests/Filter/StringsTest.php
@@ -225,35 +225,49 @@ final class StringsTest extends TestCase
     }
 
     /**
-     * Verifies basic explode functionality.
+     * @param string   $value          The value to be filtered.
+     * @param array    $expectedResult The expected filter result.
+     * @param string   $delimiter      The delimiter to use.
      *
      * @test
      * @covers ::explode
+     * @dataProvider provideExplodeData
      */
-    public function explode()
-    {
-        $this->assertSame(['a', 'bcd', 'e'], Strings::explode('a,bcd,e'));
+    public function explode(
+        string $value,
+        array $expectedResult,
+        string $delimiter = ','
+    ) {
+        $actualResult = Strings::explode($value, $delimiter);
+        $this->assertSame($expectedResult, $actualResult);
     }
 
     /**
-     * Verifies explode with a custom delimiter.
-     *
-     * @test
-     * @covers ::explode
+     * @return array
      */
-    public function explodeCustomDelimiter()
+    public function provideExplodeData() : array
     {
-        $this->assertSame(['a', 'b', 'c', 'd,e'], Strings::explode('a b c d,e', ' '));
+        return [
+            [
+                'value' => 'a,bcd,e',
+                'result' => ['a', 'bcd', 'e'],
+            ],
+            [
+                'value' => 'a b c d,e',
+                'result' => ['a', 'b', 'c', 'd,e'],
+                'delimiter' => ' ',
+            ],
+        ];
     }
 
     /**
      * @test
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage Value '1234' is not a string
      * @covers ::explode
      */
     public function explodeNonString()
     {
+        $this->expectException(FilterException::class);
+        $this->expectExceptionMessage("Value '1234' is not a string");
         Strings::explode(1234, '');
     }
 
@@ -261,12 +275,12 @@ final class StringsTest extends TestCase
      * Verifies explode filter with an empty delimiter.
      *
      * @test
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Delimiter '''' is not a non-empty string
      * @covers ::explode
      */
     public function explodeEmptyDelimiter()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Delimiter '''' is not a non-empty string");
         Strings::explode('test', '');
     }
 

--- a/tests/Filter/StringsTest.php
+++ b/tests/Filter/StringsTest.php
@@ -228,6 +228,9 @@ final class StringsTest extends TestCase
      * @param string   $value          The value to be filtered.
      * @param array    $expectedResult The expected filter result.
      * @param string   $delimiter      The delimiter to use.
+     * @param int|null $padLength      The array length of the result.
+     * @param mixed    $padValue       The value to use when padding.
+     * @param string   $padType        The direction to pad the resulting array.
      *
      * @test
      * @covers ::explode
@@ -236,9 +239,12 @@ final class StringsTest extends TestCase
     public function explode(
         string $value,
         array $expectedResult,
-        string $delimiter = ','
+        string $delimiter = ',',
+        int $padLength = null,
+        $padValue = null,
+        string $padType = Strings::EXPLODE_PAD_RIGHT
     ) {
-        $actualResult = Strings::explode($value, $delimiter);
+        $actualResult = Strings::explode($value, $delimiter, $padLength, $padValue, $padType);
         $this->assertSame($expectedResult, $actualResult);
     }
 
@@ -257,7 +263,34 @@ final class StringsTest extends TestCase
                 'result' => ['a', 'b', 'c', 'd,e'],
                 'delimiter' => ' ',
             ],
+            [
+                'value' => 'a-b-c',
+                'result' => ['a', 'b', 'c', null, null],
+                'delimiter' => '-',
+                'padLength' => 5,
+                'padValue' => null,
+                'padType' => Strings::EXPLODE_PAD_RIGHT,
+            ],
+            [
+                'value' => 'a-b-c',
+                'result' => [null, null, 'a', 'b', 'c'],
+                'delimiter' => '-',
+                'padLength' => 5,
+                'padValue' => null,
+                'padType' => Strings::EXPLODE_PAD_LEFT,
+            ],
         ];
+    }
+
+    /**
+     * @test
+     * @covers ::explode
+     */
+    public function explodeWithInvalidPadType()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid $padType value provided');
+        Strings::explode('a,b,c', ',', 4, null, 'invalid');
     }
 
     /**


### PR DESCRIPTION
#### What does this PR do?
This pull request updates the `Strings::explode` method to allow padding of the resulting array.
#### Checklist
- [  ] Pull request contains a clear definition of changes
- [  ] Tests (either unit, integration, or acceptance) written and passing
- [  ] Relevant documentation produced and/or updated

