### PR TITLE
Add Support for PHP 8.

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4']
+        php-versions: ['7.3', '7.4', '8.0', '8.1']
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -13,15 +13,15 @@
     },
     "license": "MIT",
     "require": {
-        "php": "^7.0",
-        "traderinteractive/exceptions": "^1.0"
+        "php": "^7.3 || ^8.0",
+        "traderinteractive/exceptions": "^2.0"
     },
     "require-dev": {
         "ext-SimpleXML": "*",
         "ext-dom": "*",
         "ext-json": "*",
         "ext-libxml": "*",
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^9.0",
         "squizlabs/php_codesniffer": "^3.2"
     },
     "suggest": {

--- a/tests/Filter/EmailTest.php
+++ b/tests/Filter/EmailTest.php
@@ -22,23 +22,23 @@ final class EmailTest extends TestCase
 
     /**
      * @test
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage Value '111222333444' is not a string
      * @covers ::filter
      */
     public function filterNotString()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage("Value '111222333444' is not a string");
         Email::filter(111222333444);
     }
 
     /**
      * @test
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage Value '@email.com' is not a valid email
      * @covers ::filter
      */
     public function filterNotValid()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage("Value '@email.com' is not a valid email");
         Email::filter('@email.com');
     }
 }

--- a/tests/Filter/StringsTest.php
+++ b/tests/Filter/StringsTest.php
@@ -57,12 +57,12 @@ final class StringsTest extends TestCase
 
     /**
      * @test
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage Value failed filtering, $allowNull is set to false
      * @covers ::filter
      */
     public function filterNullFail()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage('Value failed filtering, $allowNull is set to false');
         Strings::filter(null);
     }
 
@@ -77,11 +77,11 @@ final class StringsTest extends TestCase
 
     /**
      * @test
-     * @expectedException \TraderInteractive\Exceptions\FilterException
      * @covers ::filter
      */
     public function filterMinLengthFail()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
         Strings::filter('');
     }
 
@@ -96,56 +96,56 @@ final class StringsTest extends TestCase
 
     /**
      * @test
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage Value 'a' with length '1' is less than '0' or greater than '0'
      * @covers ::filter
      */
     public function filterMaxLengthFail()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage("Value 'a' with length '1' is less than '0' or greater than '0'");
         Strings::filter('a', false, 0, 0);
     }
 
     /**
      * @test
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage $minLength was not a positive integer value
      * @covers ::filter
      */
     public function filterMinLengthNotInteger()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('$minLength was not a positive integer value');
         Strings::filter('a', false, -1);
     }
 
     /**
      * @test
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage $maxLength was not a positive integer value
      * @covers ::filter
      */
     public function filterMaxLengthNotInteger()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('$maxLength was not a positive integer value');
         Strings::filter('a', false, 1, -1);
     }
 
     /**
      * @test
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage $minLength was not a positive integer value
      * @covers ::filter
      */
     public function filterMinLengthNegative()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('$minLength was not a positive integer value');
         Strings::filter('a', false, -1);
     }
 
     /**
      * @test
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage $maxLength was not a positive integer value
      * @covers ::filter
      */
     public function filterMaxLengthNegative()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('$maxLength was not a positive integer value');
         Strings::filter('a', false, 1, -1);
     }
 
@@ -184,12 +184,11 @@ final class StringsTest extends TestCase
     /**
      * @test
      * @covers ::filter
-     *
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage Value 'class@anonymous
      */
     public function filterWithObjectNoToStringMethod()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage("Value 'class@anonymous");
         $testObject = new class() {
             private $data;
 
@@ -215,11 +214,11 @@ final class StringsTest extends TestCase
     /**
      * @test
      * @covers ::translate
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage The value 'baz' was not found in the translation map array.
      */
     public function translateValueNotFoundInMap()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage("The value 'baz' was not found in the translation map array.");
         $map = ['foo' => '100', 'bar' => '200'];
         Strings::translate('baz', $map);
     }
@@ -248,12 +247,12 @@ final class StringsTest extends TestCase
 
     /**
      * @test
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage Value '1234' is not a string
      * @covers ::explode
      */
     public function explodeNonString()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage("Value '1234' is not a string");
         Strings::explode(1234, '');
     }
 
@@ -261,12 +260,12 @@ final class StringsTest extends TestCase
      * Verifies explode filter with an empty delimiter.
      *
      * @test
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Delimiter '''' is not a non-empty string
      * @covers ::explode
      */
     public function explodeEmptyDelimiter()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Delimiter '''' is not a non-empty string");
         Strings::explode('test', '');
     }
 
@@ -348,12 +347,12 @@ final class StringsTest extends TestCase
      *
      * @test
      * @covers ::concat
-     * @expectedException \TraderInteractive\Exceptions\FilterException
      *
      * @return void
      */
     public function concatValueNotFilterable()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
         Strings::concat(new \StdClass(), 'prefix', 'suffix');
     }
 

--- a/tests/Filter/UrlTest.php
+++ b/tests/Filter/UrlTest.php
@@ -22,23 +22,23 @@ final class UrlTest extends TestCase
 
     /**
      * @test
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage Value '1' is not a string
      * @covers ::filter
      */
     public function filterNonString()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage("Value '1' is not a string");
         Url::filter(1);
     }
 
     /**
      * @test
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage Value 'www.example.com' is not a valid url
      * @covers ::filter
      */
     public function filterNotValid()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage("Value 'www.example.com' is not a valid url");
         Url::filter('www.example.com');
     }
 
@@ -53,12 +53,12 @@ final class UrlTest extends TestCase
 
     /**
      * @test
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage Value failed filtering, $allowNull is set to false
      * @covers ::filter
      */
     public function filterNullFail()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage('Value failed filtering, $allowNull is set to false');
         Url::filter(null);
     }
 }


### PR DESCRIPTION
#### What does this PR do?
Add Support for PHP 8.
Backwards breaking; Remove support for PHP 7.2 and earlier.
Upgrade to PHPUnit 9.

#### Checklist
- [  ] Pull request contains a clear definition of changes
- [  ] Tests (either unit, integration, or acceptance) written and passing
- [  ] Relevant documentation produced and/or updated

