### PR TITLE
AGI-1181: Add Strings::stripEmoji

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,17 @@ $value = \TraderInteractive\Filter\Strings::redact('a string with some unwanted 
 assert($value === 'a string with some ******** *****');
 ```
 
+#### Strings::stripEmoji
+
+This filter will strip emoji, pictographs, alphanumeric supplement characters and more from a given string.
+
+The second, optional argument specifies a replacement string for the removed characters.
+
+```php
+\TraderInteractive\Filter\Strings::stripTags('🙄 this is ridiculous', ' ');
+assert($value === '  this is ridiculous');
+
+```
 #### Strings::stripTags
 
 This filter will strip HTML, XML, and PHP tags from a string. This filter also accepts null values, which will be returned as null.

--- a/src/Filter/Strings.php
+++ b/src/Filter/Strings.php
@@ -182,6 +182,37 @@ final class Strings
         return strip_tags($valueWithReplacements); // use built-in as a safeguard to ensure tags are stripped
     }
 
+    /**
+     * Strip emoji character and various other pictograph characters
+     *
+     * @param string $value       The input string.
+     * @param string $replacement The string to replace the tags with. Defaults to an empty string.
+     *
+     * @return string;
+     */
+    public static function stripEmoji(string $value, string $replacement = '')
+    {
+        $alphanumericSupplement = '/[\x{1F100}-\x{1F1FF}]/u';
+        $pictographRegex = '/[\x{1F300}-\x{1F5FF}]/u';
+        $emoticonRegex = '/[\x{1F600}-\x{1F64F}]/u';
+        $transportSymbolRegex = '/[\x{1F680}-\x{1F6FF}]/u';
+        $supplementalSymbolRegex = '/[\x{1F900}-\x{1F9FF}]/u';
+        $miscSymbolsRegex = '/[\x{2600}-\x{26FF}]/u';
+        $dingbatsRegex = '/[\x{2700}-\x{27BF}]/u';
+
+        $regexPatterns = [
+            $alphanumericSupplement,
+            $pictographRegex,
+            $emoticonRegex,
+            $transportSymbolRegex,
+            $supplementalSymbolRegex,
+            $miscSymbolsRegex,
+            $dingbatsRegex,
+        ];
+
+        return preg_replace($regexPatterns, $replacement, $value);
+    }
+
     private static function validateMinimumLength(int $minLength)
     {
         if ($minLength < 0) {

--- a/src/Filter/Strings.php
+++ b/src/Filter/Strings.php
@@ -190,7 +190,7 @@ final class Strings
      *
      * @return string;
      */
-    public static function stripEmoji(string $value, string $replacement = '')
+    public static function stripEmoji(string $value, string $replacement = ''): string
     {
         $alphanumericSupplement = '/[\x{1F100}-\x{1F1FF}]/u';
         $pictographRegex = '/[\x{1F300}-\x{1F5FF}]/u';

--- a/tests/Filter/StringsTest.php
+++ b/tests/Filter/StringsTest.php
@@ -555,7 +555,7 @@ final class StringsTest extends TestCase
      * @test
      * @dataProvider provideStripEmoji
      */
-    public function stripEmoji(string $input, string $expectedValue)
+    public function stripEmoji(string $input, string $expectedValue): void
     {
         $actualValue = Strings::stripEmoji($input);
         $this->assertSame($expectedValue, $actualValue);

--- a/tests/Filter/StringsTest.php
+++ b/tests/Filter/StringsTest.php
@@ -567,6 +567,12 @@ final class StringsTest extends TestCase
     public static function provideStripEmoji(): array
     {
         return [
+            'mulitple emoji' => [
+                'input' => 'This 💩 text contains 😞 multiple emoji 🍔 characters 🍚. As well as an alphanumeric '
+                . 'supplement 🆗 and flag 🚩',
+                'expected' => 'This  text contains  multiple emoji  characters . As well as an alphanumeric '
+                . 'supplement  and flag ',
+            ],
             'emoji' => [
                 'input' => '🙄 this is ridiculous',
                 'expected' => ' this is ridiculous',

--- a/tests/Filter/StringsTest.php
+++ b/tests/Filter/StringsTest.php
@@ -547,4 +547,42 @@ final class StringsTest extends TestCase
             ],
         ];
     }
+
+    /**
+     * @param string $input         The string value to be filtered.
+     * @param string $expectedValue The expected filtered value.
+     *
+     * @test
+     * @dataProvider provideStripEmoji
+     */
+    public function stripEmoji(string $input, string $expectedValue)
+    {
+        $actualValue = Strings::stripEmoji($input);
+        $this->assertSame($expectedValue, $actualValue);
+    }
+
+    /**
+     * @return array
+     */
+    public static function provideStripEmoji(): array
+    {
+        return [
+            'emoji' => [
+                'input' => '🙄 this is ridiculous',
+                'expected' => ' this is ridiculous',
+            ],
+            'alphanumeric supplement' => [
+                'input' => 'Contains a 🆗 character',
+                'expected' => 'Contains a  character',
+            ],
+            'flag/transportation symbols' => [
+                'input' => 'Contains a 🚩 character',
+                'expected' => 'Contains a  character',
+            ],
+            'dingbat symbols' => [
+                'input' => 'Contains a ❗ character',
+                'expected' => 'Contains a  character',
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
#### What does this PR do?
This pull request adds the `Strings::stripEmoji` method which will strip emoji characters from a given string.
#### Checklist
- [ ] Pull request contains a clear definition of changes
- [ ] Tests (either unit, integration, or acceptance) written and passing
- [ ] Relevant documentation produced and/or updated

